### PR TITLE
CORDA-1131 Fix webserver startup when headless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.corda_release_group = 'net.corda'
     ext.corda_release_version = 'corda-3.0-RC01'
-    ext.corda_gradle_plugins_version = '3.0.8'
+    ext.corda_gradle_plugins_version = '3.0.9'
     ext.kotlin_version = '1.1.60'
     ext.junit_version = '4.12'
     ext.quasar_version = '0.7.9'


### PR DESCRIPTION
depends on plugins 3.0.9, which is in pre-release-V3 but not released yet